### PR TITLE
Add interactive NeoTavla backgammon web app

### DIFF
--- a/backgammon/app.js
+++ b/backgammon/app.js
@@ -1,0 +1,786 @@
+const POINT_COUNT = 24;
+const CHECKERS_PER_PLAYER = 15;
+const PLAYER_CONFIG = {
+  white: {
+    direction: -1,
+    homeRange: [0, 5],
+    enterMap: (die) => 24 - die,
+    name: "Beyaz"
+  },
+  black: {
+    direction: 1,
+    homeRange: [18, 23],
+    enterMap: (die) => die - 1,
+    name: "Siyah"
+  }
+};
+
+const initialBoard = () => {
+  const board = Array.from({ length: POINT_COUNT }, () => ({ count: 0, color: null }));
+  const apply = (index, color, count) => {
+    board[index] = { count, color };
+  };
+
+  apply(23, "white", 2);
+  apply(12, "white", 5);
+  apply(7, "white", 3);
+  apply(5, "white", 5);
+
+  apply(0, "black", 2);
+  apply(11, "black", 5);
+  apply(16, "black", 3);
+  apply(18, "black", 5);
+  return board;
+};
+
+const state = {
+  board: initialBoard(),
+  bar: { white: 0, black: 0 },
+  off: { white: 0, black: 0 },
+  currentPlayer: "white",
+  dice: [],
+  matchType: "human-human",
+  players: {
+    white: { name: "Selin", type: "human" },
+    black: { name: "Bora", type: "human" }
+  },
+  matchLength: 3,
+  scores: { white: 0, black: 0 },
+  rolled: false,
+  selected: null,
+  validTargets: [],
+  moveLog: [],
+  suggestions: [],
+  gameOver: false
+};
+
+const boardElement = document.getElementById("board");
+const rollButton = document.getElementById("rollDice");
+const endTurnButton = document.getElementById("endTurn");
+const statusLine = document.getElementById("statusLine");
+const moveLogElement = document.getElementById("moveLog");
+const diceDisplay = document.getElementById("diceDisplay");
+const turnIndicator = document.getElementById("turnIndicator");
+const whiteOff = document.getElementById("whiteOff");
+const blackOff = document.getElementById("blackOff");
+const suggestionsElement = document.getElementById("suggestions");
+const whiteNameDisplay = document.getElementById("whiteNameDisplay");
+const blackNameDisplay = document.getElementById("blackNameDisplay");
+const whiteTypeDisplay = document.getElementById("whiteTypeDisplay");
+const blackTypeDisplay = document.getElementById("blackTypeDisplay");
+const whiteProgress = document.getElementById("whiteProgress");
+const blackProgress = document.getElementById("blackProgress");
+const whiteScore = document.getElementById("whiteScore");
+const blackScore = document.getElementById("blackScore");
+const matchTarget = document.getElementById("matchTarget");
+
+const setupPanel = document.getElementById("setupPanel");
+const gameArea = document.getElementById("gameArea");
+const showSettings = document.getElementById("showSettings");
+const openTutorial = document.getElementById("openTutorial");
+const tutorialModal = document.getElementById("tutorialModal");
+const closeTutorial = document.getElementById("closeTutorial");
+
+function resetBoard() {
+  state.board = initialBoard();
+  state.bar = { white: 0, black: 0 };
+  state.off = { white: 0, black: 0 };
+  state.currentPlayer = "white";
+  state.dice = [];
+  state.rolled = false;
+  state.selected = null;
+  state.validTargets = [];
+  state.moveLog = [];
+  state.suggestions = [];
+  state.gameOver = false;
+  render();
+}
+
+function renderBoard() {
+  boardElement.innerHTML = "";
+  const topRow = document.createElement("div");
+  topRow.className = "point-row top";
+  for (let i = 23; i >= 12; i -= 1) {
+    topRow.appendChild(createPointElement(i, "top"));
+  }
+
+  const bottomRow = document.createElement("div");
+  bottomRow.className = "point-row bottom";
+  for (let i = 0; i <= 11; i += 1) {
+    bottomRow.appendChild(createPointElement(i, "bottom"));
+  }
+
+  boardElement.append(topRow, createMiddleLayer(), bottomRow);
+}
+
+function createMiddleLayer() {
+  const layer = document.createElement("div");
+  layer.className = "point-row middle";
+
+  const barArea = document.createElement("div");
+  barArea.className = "bar-area";
+
+  ["white", "black"].forEach((color) => {
+    const slot = document.createElement("div");
+    slot.className = "bar-slot";
+    slot.dataset.type = "bar";
+    slot.dataset.color = color;
+
+    const indicator = document.createElement("span");
+    indicator.innerHTML = color === "white" ? "Beyaz Bar" : "Siyah Bar";
+
+    const count = document.createElement("div");
+    count.className = "bar-count";
+    count.textContent = state.bar[color];
+
+    if (state.bar[color] > 0 && state.currentPlayer === color) {
+      slot.classList.add("valid");
+    }
+    if (state.selected === "bar" && state.currentPlayer === color) {
+      slot.classList.add("selected");
+    }
+
+    slot.append(indicator, count);
+    slot.addEventListener("click", () => handleBarClick(color));
+    barArea.appendChild(slot);
+  });
+
+  const whiteHome = document.createElement("div");
+  whiteHome.className = "home-area white";
+  whiteHome.dataset.type = "home";
+  whiteHome.dataset.color = "white";
+  whiteHome.innerHTML = `<span>Beyaz Ev</span><strong>${state.off.white}</strong>`;
+  if (state.currentPlayer === "white" && state.validTargets.includes("home")) {
+    whiteHome.classList.add("valid");
+  }
+  whiteHome.addEventListener("click", () => handleHomeClick("white"));
+
+  const blackHome = document.createElement("div");
+  blackHome.className = "home-area black";
+  blackHome.dataset.type = "home";
+  blackHome.dataset.color = "black";
+  blackHome.innerHTML = `<span>Siyah Ev</span><strong>${state.off.black}</strong>`;
+  if (state.currentPlayer === "black" && state.validTargets.includes("home")) {
+    blackHome.classList.add("valid");
+  }
+  blackHome.addEventListener("click", () => handleHomeClick("black"));
+
+  layer.append(whiteHome, barArea, blackHome);
+  return layer;
+}
+
+function createPointElement(index, rowClass) {
+  const point = document.createElement("div");
+  point.className = `point ${rowClass} ${index % 2 === 0 ? "" : "alt"}`.trim();
+  point.dataset.index = index;
+
+  const { count, color } = state.board[index];
+  if (state.selected === index) {
+    point.classList.add("selected");
+  }
+
+  if (state.validTargets.includes(index)) {
+    point.classList.add("valid");
+  }
+
+  if (count > 0) {
+    for (let i = 0; i < count; i += 1) {
+      const checker = document.createElement("div");
+      checker.className = `checker ${color}`;
+      point.appendChild(checker);
+    }
+  }
+
+  point.addEventListener("click", () => handlePointClick(index));
+  return point;
+}
+
+function renderMeta() {
+  whiteOff.textContent = state.off.white;
+  blackOff.textContent = state.off.black;
+  whiteNameDisplay.textContent = state.players.white.name;
+  blackNameDisplay.textContent = state.players.black.name;
+  whiteTypeDisplay.textContent = state.players.white.type === "human" ? "İnsan oyuncu" : "Yapay zeka";
+  blackTypeDisplay.textContent = state.players.black.type === "human" ? "İnsan oyuncu" : "Yapay zeka";
+  whiteScore.textContent = state.scores.white;
+  blackScore.textContent = state.scores.black;
+  matchTarget.textContent = `${state.matchLength} puanlık seri`;
+
+  const whiteRatio = (state.scores.white / state.matchLength) * 100;
+  const blackRatio = (state.scores.black / state.matchLength) * 100;
+  whiteProgress.style.width = `${Math.min(100, whiteRatio)}%`;
+  blackProgress.style.width = `${Math.min(100, blackRatio)}%`;
+
+  const activeName = state.currentPlayer === "white" ? state.players.white.name : state.players.black.name;
+  turnIndicator.textContent = state.gameOver
+    ? "Oyun tamamlandı"
+    : `Hamle sırası: ${activeName}`;
+  rollButton.disabled = state.rolled || !isHumanTurn() || state.gameOver;
+  endTurnButton.disabled = !state.rolled || state.dice.length > 0 || state.gameOver;
+}
+
+function renderDice() {
+  diceDisplay.innerHTML = "";
+  state.dice.forEach((value) => {
+    const die = document.createElement("div");
+    die.className = "dice";
+    die.textContent = value;
+    diceDisplay.appendChild(die);
+  });
+}
+
+function renderLog() {
+  moveLogElement.innerHTML = "";
+  state.moveLog.slice(-10).forEach((entry) => {
+    const li = document.createElement("li");
+    li.textContent = entry;
+    moveLogElement.appendChild(li);
+  });
+}
+
+function renderSuggestions() {
+  suggestionsElement.textContent = state.suggestions.length
+    ? state.suggestions.join(" • ")
+    : "Zar atıldığında öneriler burada belirecek.";
+}
+
+function renderStatus(message, type = "") {
+  statusLine.textContent = message;
+  statusLine.className = `status-line ${type}`.trim();
+}
+
+function render() {
+  renderBoard();
+  renderMeta();
+  renderDice();
+  renderLog();
+  renderSuggestions();
+}
+
+function isHumanTurn() {
+  return state.players[state.currentPlayer].type === "human";
+}
+
+function rollDice() {
+  if (state.rolled || state.gameOver) return;
+  state.dice = [randomDie(), randomDie()];
+  if (state.dice[0] === state.dice[1]) {
+    state.dice = Array(4).fill(state.dice[0]);
+  }
+  state.rolled = true;
+  renderDice();
+  updateSuggestions();
+  renderStatus(`${PLAYER_CONFIG[state.currentPlayer].name} oyuncusu ${state.dice.join("-")} attı.`);
+  if (!hasAnyValidMove(state.currentPlayer)) {
+    renderStatus("Geçerli hamle yok, sıra rakibe geçiyor.", "error");
+    endTurn();
+  } else if (!isHumanTurn()) {
+    setTimeout(runAiTurn, 550);
+  }
+  renderMeta();
+}
+
+function randomDie() {
+  return Math.floor(Math.random() * 6) + 1;
+}
+
+function handlePointClick(index) {
+  if (!state.rolled || !isHumanTurn() || state.gameOver) return;
+  const point = state.board[index];
+  const current = state.currentPlayer;
+
+  if (state.bar[current] > 0 && state.selected !== "bar") {
+    renderStatus("Önce bardaki pulları oyuna sokmalısın.", "error");
+    return;
+  }
+
+  if (point.color === current && point.count > 0) {
+    state.selected = index;
+    state.validTargets = computeValidTargetsFromPoint(index);
+  } else if (state.selected !== null && state.validTargets.includes(index)) {
+    moveChecker(state.selected, index);
+    state.selected = null;
+    state.validTargets = [];
+    afterMove();
+  } else {
+    state.selected = null;
+    state.validTargets = [];
+  }
+  renderBoard();
+}
+
+function handleBarClick(color) {
+  if (!state.rolled || !isHumanTurn() || state.gameOver) return;
+  if (color !== state.currentPlayer) return;
+  if (state.bar[color] === 0) return;
+  state.selected = "bar";
+  state.validTargets = computeValidTargetsFromBar(color);
+  renderBoard();
+}
+
+function handleHomeClick(color) {
+  if (!state.rolled || !isHumanTurn() || state.gameOver) return;
+  if (color !== state.currentPlayer) return;
+  if (state.selected !== null && state.validTargets.includes("home")) {
+    bearOff(state.selected);
+    state.selected = null;
+    state.validTargets = [];
+    afterMove();
+  }
+}
+
+function computeValidTargetsFromPoint(index) {
+  const current = state.currentPlayer;
+  const dice = [...state.dice];
+  const targets = [];
+
+  dice.forEach((die) => {
+    const targetIndex = index + die * PLAYER_CONFIG[current].direction;
+    if (isValidLanding(index, targetIndex, die)) {
+      targets.push(targetIndex);
+    } else if (canBearOffFrom(index, die)) {
+      targets.push("home");
+    }
+  });
+
+  return Array.from(new Set(targets));
+}
+
+function computeValidTargetsFromBar(color) {
+  const dice = [...state.dice];
+  const targets = [];
+
+  dice.forEach((die) => {
+    const targetIndex = PLAYER_CONFIG[color].enterMap(die);
+    if (isValidLanding("bar", targetIndex, die, color)) {
+      targets.push(targetIndex);
+    }
+  });
+
+  return Array.from(new Set(targets));
+}
+
+function isValidLanding(from, to, die, colorOverride) {
+  const player = colorOverride || state.currentPlayer;
+  if (typeof to !== "number" || to < 0 || to >= POINT_COUNT) {
+    return false;
+  }
+  const targetPoint = state.board[to];
+  if (targetPoint.color && targetPoint.color !== player && targetPoint.count > 1) {
+    return false;
+  }
+
+  const direction = PLAYER_CONFIG[player].direction;
+  if (player === "white" && ((from !== "bar" && to >= from) || direction !== -1)) {
+    if (from !== "bar" && to >= from) return false;
+  }
+  if (player === "black" && ((from !== "bar" && to <= from) || direction !== 1)) {
+    if (from !== "bar" && to <= from) return false;
+  }
+
+  if (!state.dice.includes(die)) {
+    return false;
+  }
+
+  if (from !== "bar" && !canUseDieForMove(from, to, die, player)) {
+    return false;
+  }
+
+  return true;
+}
+
+function canUseDieForMove(from, to, die, player) {
+  const direction = PLAYER_CONFIG[player].direction;
+  const distance = Math.abs(to - from);
+  return distance === die && Math.sign(to - from) === direction;
+}
+
+function canBearOffFrom(index, die) {
+  const player = state.currentPlayer;
+  if (!allCheckersInHome(player)) return false;
+  if (!state.dice.includes(die)) return false;
+
+  const homeRange = PLAYER_CONFIG[player].homeRange;
+  if (index < homeRange[0] || index > homeRange[1]) return false;
+
+  if (player === "white") {
+    const target = index - die;
+    if (target === -1) return true;
+    if (target < -1) {
+      const hasHigher = state.board.slice(index + 1, homeRange[1] + 1)
+        .some((point) => point.color === player && point.count > 0);
+      return !hasHigher;
+    }
+    return false;
+  }
+
+  const target = index + die;
+  if (target === 24) return true;
+  if (target > 24) {
+    const hasHigher = state.board.slice(homeRange[0], index)
+      .some((point) => point.color === player && point.count > 0);
+    return !hasHigher;
+  }
+  return false;
+}
+
+function moveChecker(from, to) {
+  const player = state.currentPlayer;
+  let dieUsed = Math.abs((typeof to === "number" ? to : 0) - (typeof from === "number" ? from : 0));
+
+  if (from === "bar") {
+    state.bar[player] -= 1;
+    dieUsed = Math.abs(PLAYER_CONFIG[player].enterMap(0) - to);
+  } else {
+    state.board[from].count -= 1;
+    if (state.board[from].count === 0) {
+      state.board[from].color = null;
+    }
+  }
+
+  if (typeof to === "number") {
+    const targetPoint = state.board[to];
+    if (targetPoint.color && targetPoint.color !== player) {
+      // Hit opponent checker
+      state.bar[targetPoint.color] += 1;
+      targetPoint.count = 0;
+      targetPoint.color = null;
+    }
+    if (targetPoint.color === player || targetPoint.count === 0) {
+      targetPoint.color = player;
+      targetPoint.count += 1;
+    }
+  }
+
+  consumeDie(Math.abs(from === "bar" ? computeDieFromBar(to, player) : dieUsed));
+
+  const dieValue = Math.abs(from === "bar" ? computeDieFromBar(to, player) : dieUsed);
+  logMove(`${state.players[player].name} ${fromLabel(from)} → ${toLabel(to)} (${dieValue})`);
+}
+
+function computeDieFromBar(to, player) {
+  const entryIndex = to;
+  if (player === "white") {
+    return 24 - entryIndex;
+  }
+  return entryIndex + 1;
+}
+
+function bearOff(from) {
+  const player = state.currentPlayer;
+  state.board[from].count -= 1;
+  if (state.board[from].count === 0) {
+    state.board[from].color = null;
+  }
+  state.off[player] += 1;
+
+  const die = computeBearOffDie(from, player);
+  consumeDie(die);
+  logMove(`${state.players[player].name} ${fromLabel(from)} → Ev (${die})`);
+  checkVictory();
+}
+
+function consumeDie(value) {
+  const index = state.dice.indexOf(value);
+  if (index > -1) {
+    state.dice.splice(index, 1);
+  } else {
+    // allow using higher die during bear off
+    const largerIndex = state.dice.findIndex((die) => die > value);
+    if (largerIndex > -1) {
+      state.dice.splice(largerIndex, 1);
+    }
+  }
+  renderDice();
+}
+
+function afterMove() {
+  if (state.gameOver) return;
+  renderBoard();
+  renderMeta();
+  renderDice();
+  updateSuggestions();
+  if (state.dice.length === 0) {
+    endTurnButton.disabled = false;
+  }
+  if (!hasAnyValidMove(state.currentPlayer)) {
+    renderStatus("Kalan zarlarla hamle yapılamıyor.", "error");
+    endTurn();
+  }
+}
+
+function endTurn() {
+  if (state.gameOver) return;
+  state.dice = [];
+  state.rolled = false;
+  state.selected = null;
+  state.validTargets = [];
+  state.currentPlayer = state.currentPlayer === "white" ? "black" : "white";
+  render();
+  updateSuggestions();
+  renderStatus(`${state.players[state.currentPlayer].name} zar atabilir.`);
+  if (!isHumanTurn()) {
+    setTimeout(runAiTurn, 600);
+  }
+}
+
+function logMove(text) {
+  state.moveLog.push(text);
+  renderLog();
+}
+
+function fromLabel(from) {
+  if (from === "bar") return "Bar";
+  return `${from + 1}`;
+}
+
+function toLabel(to) {
+  if (to === "home") return "Ev";
+  return `${(to ?? 0) + 1}`;
+}
+
+function hasAnyValidMove(player) {
+  if (!state.rolled) return true;
+  if (state.bar[player] > 0) {
+    return computeValidTargetsFromBar(player).length > 0;
+  }
+
+  for (let i = 0; i < POINT_COUNT; i += 1) {
+    if (state.board[i].color === player && state.board[i].count > 0) {
+      const targets = computeValidTargetsFromPoint(i);
+      if (targets.length > 0) return true;
+    }
+  }
+  return false;
+}
+
+function allCheckersInHome(player) {
+  const homeRange = PLAYER_CONFIG[player].homeRange;
+  for (let i = 0; i < POINT_COUNT; i += 1) {
+    const point = state.board[i];
+    if (point.color === player) {
+      if (player === "white" && i > homeRange[1]) return false;
+      if (player === "black" && i < homeRange[0]) return false;
+    }
+  }
+  return state.bar[player] === 0;
+}
+
+function updateSuggestions() {
+  if (!state.rolled) {
+    state.suggestions = [];
+    renderSuggestions();
+    return;
+  }
+
+  const moves = enumeratePossibleMoves(state.currentPlayer);
+  if (moves.length === 0) {
+    state.suggestions = ["Hamle yapılamıyor"];
+  } else {
+    state.suggestions = moves.slice(0, 3).map((move) => move.description);
+  }
+  renderSuggestions();
+}
+
+function enumeratePossibleMoves(player) {
+  const result = [];
+  const dice = [...state.dice];
+  if (!dice.length) return result;
+
+  if (state.bar[player] > 0) {
+    dice.forEach((die) => {
+      const target = PLAYER_CONFIG[player].enterMap(die);
+      if (isValidLanding("bar", target, die, player)) {
+        result.push({ description: `Bardan ${target + 1}. haneye giriş (${die})` });
+      }
+    });
+    return result;
+  }
+
+  state.board.forEach((point, index) => {
+    if (point.color === player && point.count > 0) {
+      dice.forEach((die) => {
+        const target = index + die * PLAYER_CONFIG[player].direction;
+        if (isValidLanding(index, target, die, player)) {
+          result.push({ description: `${index + 1} → ${target + 1} (${die})` });
+        } else if (canBearOffFrom(index, die)) {
+          result.push({ description: `${index + 1} → Ev (${die})` });
+        }
+      });
+    }
+  });
+
+  return result;
+}
+
+function runAiTurn() {
+  if (state.gameOver) return;
+  if (isHumanTurn()) return;
+  if (!state.rolled) {
+    rollDice();
+    return;
+  }
+
+  const player = state.currentPlayer;
+  const possibleMoves = () => {
+    const moves = [];
+    if (state.bar[player] > 0) {
+      state.dice.forEach((die) => {
+        const target = PLAYER_CONFIG[player].enterMap(die);
+        if (isValidLanding("bar", target, die, player)) {
+          moves.push({ from: "bar", to: target, die });
+        }
+      });
+      return moves;
+    }
+
+    state.board.forEach((point, index) => {
+      if (point.color === player && point.count > 0) {
+        state.dice.forEach((die) => {
+          const target = index + die * PLAYER_CONFIG[player].direction;
+          if (isValidLanding(index, target, die, player)) {
+            moves.push({ from: index, to: target, die });
+          } else if (canBearOffFrom(index, die)) {
+            moves.push({ from: index, to: "home", die });
+          }
+        });
+      }
+    });
+    return moves;
+  };
+
+  const moves = possibleMoves();
+  if (!moves.length) {
+    renderStatus("Yapay zeka hamle yapamadı.", "error");
+    endTurn();
+    return;
+  }
+
+  const chosen = chooseAiMove(moves);
+  if (state.gameOver) return;
+  if (chosen.from === "bar") {
+    state.bar[player] -= 1;
+    const targetPoint = state.board[chosen.to];
+    if (targetPoint.color && targetPoint.color !== player) {
+      state.bar[targetPoint.color] += 1;
+      targetPoint.count = 0;
+      targetPoint.color = null;
+    }
+    targetPoint.color = player;
+    targetPoint.count += 1;
+    consumeDie(chosen.die);
+    logMove(`${state.players[player].name} (YZ) Bar → ${chosen.to + 1} (${chosen.die})`);
+  } else if (chosen.to === "home") {
+    bearOff(chosen.from);
+  } else {
+    moveChecker(chosen.from, chosen.to);
+  }
+
+  if (state.gameOver) return;
+  render();
+
+  if (state.dice.length > 0) {
+    setTimeout(runAiTurn, 600);
+  } else {
+    endTurn();
+  }
+}
+
+function chooseAiMove(moves) {
+  const prioritized = moves.sort((a, b) => b.die - a.die);
+  return prioritized[0];
+}
+
+function computeBearOffDie(from, player) {
+  if (player === "white") {
+    const distance = from + 1;
+    const exact = state.dice.find((d) => d === distance);
+    if (exact) return exact;
+    const higher = state.dice.filter((d) => d > distance);
+    return higher.length ? Math.min(...higher) : Math.max(...state.dice);
+  }
+  const distance = 24 - from;
+  const exact = state.dice.find((d) => d === distance);
+  if (exact) return exact;
+  const higher = state.dice.filter((d) => d > distance);
+  return higher.length ? Math.min(...higher) : Math.max(...state.dice);
+}
+
+function checkVictory() {
+  if (state.off.white === CHECKERS_PER_PLAYER) {
+    state.scores.white += 1;
+    state.gameOver = true;
+    renderStatus(`${state.players.white.name} oyunu kazandı!`, "success");
+    endGame();
+  } else if (state.off.black === CHECKERS_PER_PLAYER) {
+    state.scores.black += 1;
+    state.gameOver = true;
+    renderStatus(`${state.players.black.name} oyunu kazandı!`, "success");
+    endGame();
+  }
+}
+
+function endGame() {
+  state.suggestions = ["Oyun tamamlandı. Yeni oyun oluşturabilirsiniz."];
+  render();
+  rollButton.disabled = true;
+  endTurnButton.disabled = true;
+}
+
+rollButton.addEventListener("click", () => {
+  if (state.rolled) return;
+  rollDice();
+});
+
+endTurnButton.addEventListener("click", () => {
+  if (!state.rolled) return;
+  endTurn();
+});
+
+showSettings.addEventListener("click", () => {
+  gameArea.classList.add("hidden");
+  setupPanel.classList.remove("hidden");
+});
+
+openTutorial.addEventListener("click", () => {
+  tutorialModal.showModal();
+});
+
+closeTutorial.addEventListener("click", () => {
+  tutorialModal.close();
+});
+
+tutorialModal.addEventListener("click", (event) => {
+  const rect = tutorialModal.getBoundingClientRect();
+  if (
+    event.clientX < rect.left ||
+    event.clientX > rect.right ||
+    event.clientY < rect.top ||
+    event.clientY > rect.bottom
+  ) {
+    tutorialModal.close();
+  }
+});
+
+const setupForm = document.getElementById("gameSetup");
+setupForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const data = new FormData(setupForm);
+  state.matchType = data.get("matchType");
+  state.players.white.name = document.getElementById("whiteName").value || "Beyaz";
+  state.players.black.name = document.getElementById("blackName").value || "Siyah";
+  state.players.white.type = state.matchType === "ai-ai" ? "ai" : "human";
+  state.players.black.type = state.matchType === "human-human" ? "human" : "ai";
+  state.matchLength = Number(data.get("matchLength"));
+  state.scores = { white: 0, black: 0 };
+  resetBoard();
+  renderStatus("Yeni oyun hazır, beyaz başlıyor.", "success");
+  setupPanel.classList.add("hidden");
+  gameArea.classList.remove("hidden");
+  if (!isHumanTurn()) {
+    setTimeout(runAiTurn, 600);
+  }
+});
+
+render();
+renderStatus("Oyuna hazır.");

--- a/backgammon/index.html
+++ b/backgammon/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neo Tavla - Web Tabanlı Tavla Deneyimi</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="app">
+    <header class="app-header">
+      <div class="branding">
+        <div class="logo">Neo<span>Tavla</span></div>
+        <p class="tagline">Modern web tabanlı tavla arenası</p>
+      </div>
+      <nav class="header-actions">
+        <button class="ghost" id="showSettings">Yeni Oyun</button>
+        <button class="primary" id="openTutorial">Kuralları Öğren</button>
+      </nav>
+    </header>
+
+    <main class="app-main">
+      <section class="hero" id="setupPanel">
+        <div class="setup-card glass">
+          <h1>Rakibini seç, zarını at, oyuna başla!</h1>
+          <p>NeoTavla klasik tavla hissini modern bir arayüz, zekice otomasyonlar ve çevrimiçi turnuva ruhuyla bir araya getirir.</p>
+
+          <form id="gameSetup">
+            <div class="field-group">
+              <label for="matchType">Maç Tipi</label>
+              <div class="segmented" role="radiogroup">
+                <label><input type="radio" name="matchType" value="human-human" checked><span>Oyuncu vs Oyuncu</span></label>
+                <label><input type="radio" name="matchType" value="human-ai"><span>Oyuncu vs Yapay Zeka</span></label>
+                <label><input type="radio" name="matchType" value="ai-ai"><span>Yapay Zeka Düellosu</span></label>
+              </div>
+            </div>
+
+            <div class="grid two-columns">
+              <div class="field-group">
+                <label for="whiteName">Beyaz Oyuncu</label>
+                <input id="whiteName" type="text" placeholder="Örn. Selin" value="Selin" required>
+              </div>
+              <div class="field-group">
+                <label for="blackName">Siyah Oyuncu</label>
+                <input id="blackName" type="text" placeholder="Örn. Bora" value="Bora" required>
+              </div>
+            </div>
+
+            <div class="field-group">
+              <label>Maç Uzunluğu</label>
+              <div class="segmented" role="radiogroup">
+                <label><input type="radio" name="matchLength" value="3" checked><span>3 Puan</span></label>
+                <label><input type="radio" name="matchLength" value="5"><span>5 Puan</span></label>
+                <label><input type="radio" name="matchLength" value="7"><span>7 Puan</span></label>
+              </div>
+            </div>
+
+            <button class="cta" type="submit">Oyunu Başlat</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="game hidden" id="gameArea">
+        <aside class="side-panel">
+          <div class="player-card" id="whitePanel">
+            <div class="player-meta">
+              <span class="color-indicator white"></span>
+              <h2 class="player-name" id="whiteNameDisplay">Selin</h2>
+            </div>
+            <p class="player-type" id="whiteTypeDisplay">İnsan oyuncu</p>
+            <div class="score-box">
+              <span>Puan</span>
+              <strong id="whiteScore">0</strong>
+            </div>
+            <div class="off-box">
+              <span>Toplanan Pullar</span>
+              <strong id="whiteOff">0</strong>
+            </div>
+          </div>
+
+          <div class="timeline">
+            <h3>Hamle Güncesi</h3>
+            <ul id="moveLog"></ul>
+          </div>
+
+          <div class="control-panel">
+            <button class="primary" id="rollDice">Zar At</button>
+            <button class="ghost" id="endTurn">Hamleyi Bitir</button>
+            <div class="dice-display" id="diceDisplay"></div>
+            <div class="status-line" id="statusLine">Oyuna hazır.</div>
+          </div>
+        </aside>
+
+        <section class="board-wrapper">
+          <div class="current-turn" id="turnIndicator">Hamle sırası: Beyaz</div>
+          <div class="board" id="board"></div>
+          <div class="legend">
+            <div><span class="dot white"></span>Beyaz oyuncu (ileri ↘)</div>
+            <div><span class="dot black"></span>Siyah oyuncu (ileri ↗)</div>
+          </div>
+        </section>
+
+        <aside class="side-panel">
+          <div class="player-card" id="blackPanel">
+            <div class="player-meta">
+              <span class="color-indicator black"></span>
+              <h2 class="player-name" id="blackNameDisplay">Bora</h2>
+            </div>
+            <p class="player-type" id="blackTypeDisplay">İnsan oyuncu</p>
+            <div class="score-box">
+              <span>Puan</span>
+              <strong id="blackScore">0</strong>
+            </div>
+            <div class="off-box">
+              <span>Toplanan Pullar</span>
+              <strong id="blackOff">0</strong>
+            </div>
+          </div>
+
+          <div class="analytics">
+            <h3>Hamle Önerileri</h3>
+            <p id="suggestions">Zar atıldığında öneriler burada belirecek.</p>
+          </div>
+
+          <div class="match-progress">
+            <h3>Seri Durumu</h3>
+            <div class="progress-track">
+              <span class="white" id="whiteProgress"></span>
+              <span class="black" id="blackProgress"></span>
+            </div>
+            <p class="target" id="matchTarget">3 puanlık seri</p>
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <dialog id="tutorialModal">
+      <div class="modal-header">
+        <h2>Tavla Kuralları &amp; NeoTavla Özellikleri</h2>
+        <button class="icon" id="closeTutorial" aria-label="Kapat">&times;</button>
+      </div>
+      <div class="modal-body">
+        <article>
+          <h3>Kısaca Tavla</h3>
+          <p>Tavlada her oyuncu 15 pul ile başlar. Amaç tüm pulları kendi evinize topladıktan sonra dışarı çıkarmaktır. Zar sonuçlarına göre pullarınızı hareket ettirirken rakibin yalnız pulu üzerine düşerseniz onu bara gönderirsiniz.</p>
+          <h3>NeoTavla Neler Sunar?</h3>
+          <ul>
+            <li>Akıllı hamle doğrulama ve geçerli hamle vurgulama</li>
+            <li>Yapay zeka destekli hızlı rakip</li>
+            <li>Hamle güncesi ve öneriler paneli</li>
+            <li>Modern, dokunmatik uyumlu tasarım</li>
+          </ul>
+        </article>
+      </div>
+    </dialog>
+  </div>
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/backgammon/style.css
+++ b/backgammon/style.css
@@ -1,0 +1,706 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0e1117;
+  --bg-soft: rgba(20, 24, 33, 0.85);
+  --panel: rgba(18, 22, 30, 0.75);
+  --border: rgba(255, 255, 255, 0.08);
+  --primary: #6d5dfc;
+  --primary-dark: #4b38d4;
+  --accent: #ff9f43;
+  --white: #f4f7fb;
+  --black: #10131a;
+  --success: #3dd598;
+  --danger: #ff5c5c;
+  --shadow: 0 18px 40px rgba(12, 17, 27, 0.35);
+  font-size: 16px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Poppins", "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(109, 93, 252, 0.28), transparent 45%),
+              radial-gradient(circle at 80% 0%, rgba(255, 159, 67, 0.2), transparent 40%),
+              var(--bg);
+  color: var(--white);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: clamp(16px, 3vw, 40px);
+}
+
+#app {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  backdrop-filter: blur(12px);
+  background: rgba(16, 20, 27, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 18px 28px;
+  box-shadow: var(--shadow);
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.logo {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.logo span {
+  color: var(--accent);
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: var(--white);
+  box-shadow: 0 12px 25px rgba(109, 93, 252, 0.25);
+}
+
+button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--white);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+button.cta {
+  width: 100%;
+  padding: 14px;
+  font-weight: 600;
+  background: linear-gradient(120deg, var(--primary), var(--primary-dark));
+  color: var(--white);
+  box-shadow: 0 18px 32px rgba(77, 57, 228, 0.35);
+}
+
+button.icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 1.5rem;
+  display: grid;
+  place-items: center;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero {
+  display: grid;
+  place-items: center;
+  min-height: 420px;
+}
+
+.hero.hidden {
+  display: none;
+}
+
+.setup-card {
+  width: min(600px, 100%);
+  padding: clamp(24px, 5vw, 38px);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(20, 25, 34, 0.85);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.setup-card h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+}
+
+.setup-card p {
+  margin: 0;
+  opacity: 0.8;
+  line-height: 1.6;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-group label {
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.field-group input[type="text"] {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 12px 16px;
+  color: var(--white);
+  font-size: 1rem;
+}
+
+.field-group input[type="text"]:focus {
+  outline: 2px solid rgba(109, 93, 252, 0.5);
+  outline-offset: 2px;
+}
+
+.segmented {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.segmented label {
+  position: relative;
+  cursor: pointer;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.segmented input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+
+.segmented span {
+  display: inline-flex;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.segmented input:checked + span {
+  background: linear-gradient(130deg, rgba(109, 93, 252, 0.85), rgba(255, 159, 67, 0.65));
+  border-color: transparent;
+  color: var(--white);
+  box-shadow: 0 12px 24px rgba(82, 63, 224, 0.3);
+}
+
+.grid.two-columns {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.game {
+  display: grid;
+  grid-template-columns: 270px 1fr 270px;
+  gap: 24px;
+}
+
+.game.hidden {
+  display: none;
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: rgba(16, 20, 27, 0.6);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.player-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.player-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.color-indicator {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.color-indicator.white {
+  background: linear-gradient(145deg, #fdfcff, #c3c8d3);
+}
+
+.color-indicator.black {
+  background: linear-gradient(145deg, #1c202a, #03070f);
+}
+
+.player-name {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.player-type {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
+.score-box, .off-box {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 10px 14px;
+  border-radius: 14px;
+}
+
+.timeline, .analytics, .match-progress {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.timeline h3, .analytics h3, .match-progress h3 {
+  margin-top: 0;
+  font-size: 1rem;
+}
+
+.progress-track {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.progress-track .white {
+  background: linear-gradient(135deg, rgba(244, 247, 251, 0.95), rgba(178, 185, 201, 0.7));
+}
+
+.progress-track .black {
+  background: linear-gradient(135deg, rgba(16, 19, 26, 0.95), rgba(58, 63, 78, 0.7));
+  margin-left: auto;
+}
+
+#moveLog {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.9rem;
+}
+
+#moveLog li {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 10px 12px;
+  border-radius: 14px;
+  border-left: 3px solid var(--primary);
+}
+
+.control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.dice-display {
+  display: flex;
+  gap: 10px;
+  min-height: 48px;
+  align-items: center;
+}
+
+.dice {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.7));
+  color: var(--black);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+}
+
+.status-line {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.board-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: rgba(16, 20, 27, 0.72);
+  border-radius: 32px;
+  padding: 20px 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.current-turn {
+  text-align: center;
+  font-size: 1.05rem;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.board {
+  display: grid;
+  grid-template-rows: minmax(140px, 1fr) auto minmax(140px, 1fr);
+  gap: 16px;
+  position: relative;
+}
+
+.point-row {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.point-row.middle {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  position: relative;
+  min-height: 120px;
+}
+
+.point {
+  position: relative;
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(29, 35, 48, 0.92), rgba(16, 20, 27, 0.92));
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 4px;
+  min-height: 140px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.point.bottom {
+  justify-content: flex-end;
+}
+
+.point::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent);
+}
+
+.point.alt {
+  background: linear-gradient(180deg, rgba(33, 40, 56, 0.9), rgba(16, 20, 27, 0.92));
+}
+
+.point.selected {
+  box-shadow: 0 0 0 3px rgba(109, 93, 252, 0.45);
+}
+
+.point.valid {
+  box-shadow: 0 0 0 3px rgba(61, 213, 152, 0.4);
+  transform: translateY(-2px);
+}
+
+.checker {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  box-shadow: inset 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.checker.white {
+  background: radial-gradient(circle at 30% 30%, #ffffff, #c6ccd6);
+}
+
+.checker.black {
+  background: radial-gradient(circle at 30% 30%, #0d1119, #333a4a);
+}
+
+.bar-area {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 14px 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(14px);
+}
+
+.bar-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.bar-slot span {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.bar-count {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bar-slot.valid .bar-count {
+  box-shadow: 0 0 0 3px rgba(61, 213, 152, 0.4);
+}
+
+.bar-slot.selected .bar-count {
+  box-shadow: 0 0 0 3px rgba(109, 93, 252, 0.45);
+}
+
+.home-area {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.home-area.white {
+  left: -70px;
+}
+
+.home-area.black {
+  right: -70px;
+}
+
+.home-area strong {
+  font-size: 1.1rem;
+}
+
+.home-area.valid {
+  box-shadow: 0 0 0 3px rgba(61, 213, 152, 0.4);
+  border-radius: 18px;
+  padding: 4px 10px;
+  background: rgba(61, 213, 152, 0.08);
+}
+
+.legend {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 6px;
+}
+
+.dot.white {
+  background: #f0f4ff;
+}
+
+.dot.black {
+  background: #080b12;
+}
+
+dialog {
+  border: none;
+  border-radius: 24px;
+  padding: 0;
+  background: rgba(16, 20, 27, 0.9);
+  color: var(--white);
+  width: min(560px, 90vw);
+  box-shadow: var(--shadow);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.modal-body {
+  padding: 20px 24px 28px;
+}
+
+.modal-body article {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  line-height: 1.6;
+}
+
+.modal-body ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.status-line.success {
+  color: var(--success);
+}
+
+.status-line.error {
+  color: var(--danger);
+}
+
+@media (max-width: 1100px) {
+  body {
+    padding: 16px;
+  }
+
+  .game {
+    grid-template-columns: 1fr;
+  }
+
+  .side-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .player-card, .timeline, .control-panel, .analytics, .match-progress {
+    flex: 1 1 280px;
+  }
+
+  .board-wrapper {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .board {
+    grid-template-rows: repeat(2, minmax(120px, 1fr));
+  }
+
+  .point {
+    min-height: 120px;
+  }
+
+  .home-area {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated NeoTavla page with player setup, scoreboard panels, and a tutorial modal
- craft a modern glassmorphism-inspired layout for the board, sidebars, dice, and progress tracking
- implement complete backgammon state handling including move validation, bar/home management, AI turns, and move suggestions

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01484de9c8330a2db65dcb675d687